### PR TITLE
fix(vanilla-example): CORE-12789 - add helmet

### DIFF
--- a/webplayer-example-vanilla-js/package.json
+++ b/webplayer-example-vanilla-js/package.json
@@ -19,11 +19,13 @@
     "body-parser": "^2.2.0",
     "cors": "^2.8.5",
     "express": "^5.1.0",
+    "helmet": "^8.1.0",
     "https": "^1.0.0",
     "node-fetch": "^3.3.2",
     "post-me": "^0.4.5"
   },
   "devDependencies": {
     "nodemon": "^3.1.10"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/webplayer-example-vanilla-js/package.json
+++ b/webplayer-example-vanilla-js/package.json
@@ -26,6 +26,5 @@
   },
   "devDependencies": {
     "nodemon": "^3.1.10"
-  },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  }
 }

--- a/webplayer-example-vanilla-js/server.js
+++ b/webplayer-example-vanilla-js/server.js
@@ -7,6 +7,9 @@ const bodyParser = require('body-parser');
 
 const jsonParser = bodyParser.json();
 
+const helmet = require('helmet')
+app.use(helmet())
+
 app.use(
   cors({
     origin: '*',

--- a/webplayer-example-vanilla-js/server.js
+++ b/webplayer-example-vanilla-js/server.js
@@ -7,8 +7,8 @@ const bodyParser = require('body-parser');
 
 const jsonParser = bodyParser.json();
 
-const helmet = require('helmet')
-app.use(helmet())
+const helmet = require('helmet');
+app.use(helmet());
 
 app.use(
   cors({

--- a/webplayer-example-vanilla-js/yarn.lock
+++ b/webplayer-example-vanilla-js/yarn.lock
@@ -332,6 +332,11 @@ hasown@^2.0.2:
   dependencies:
     function-bind "^1.1.2"
 
+helmet@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/helmet/-/helmet-8.1.0.tgz#f96d23fedc89e9476ecb5198181009c804b8b38c"
+  integrity sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==
+
 http-errors@2.0.0, http-errors@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-2.0.0.tgz#b7774a1486ef73cf7667ac9ae0858c012c57b9d3"


### PR DESCRIPTION
High vulnerability fix from Datadog: 

> Per [Express documentation](https://expressjs.com/en/advanced/best-practice-security.html#use-helmet):
> 
> > [Helmet](https://helmetjs.github.io/) can help protect your app from some well-known web vulnerabilities by setting HTTP headers appropriately.
> 
> This rule will check whether you've set app.use(helmet()) within the file that you've called express()